### PR TITLE
Fix fatal error saving the entities

### DIFF
--- a/my_entity.entity.inc
+++ b/my_entity.entity.inc
@@ -109,6 +109,15 @@ function my_entity_admin_add_page() {
 function my_entity_form($form, &$form_state, $my_entity) {
   $form_state['my_entity'] = $my_entity;
 
+  // Basic my_entity information.
+  // These elements are just values so they are not even sent to the client.
+  foreach (array('eid', 'uid', 'created', 'type') as $key) {
+    $form[$key] = array(
+      '#type' => 'value',
+      '#value' => isset($my_entity->$key) ? $my_entity->$key : NULL,
+    );
+  }
+
   $form['title'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,


### PR DESCRIPTION
entity_form_field_validate builds the entity to validate from the $form_state['values'] data, and raises a fatal error because it can't find the bundle.
