### PR TITLE
Trying to delete an entity doesn't work

### DIFF
--- a/my_entity.entity.inc
+++ b/my_entity.entity.inc
@@ -201,7 +201,7 @@ function my_entity_form_submit_delete($form, &$form_state) {
   }
   $my_entity = $form_state['my_entity'];
   $my_entity_uri = entity_uri('my_entity', $my_entity);
-  $form_state['redirect'] = array($my_entity_uri['path'] . '/delete', array('query' => $destination));
+  $form_state['redirect'] = array('admin/content/' . $my_entity_uri['path'] . '/delete', array('query' => $destination));
 
 }
 


### PR DESCRIPTION
When trying to delete an entity (instance of one of my types), I can see the form and the delete button, but the delete button doesn't work as expected, when I press it nothing happens (besides a redirection to the entity_module/id).
It should show the confirm_form (for deletion).

I've noticed that the path should include 'admin/content' in the my_entity_form_submit_delete() handler.

To get the propper path, we can hardcoded it because it is in the .module

```
'admin ui' => array(
      'path' => 'admin/content/my_entity',
      'file' => 'my_entity.entity.inc',
      'controller class' => '\Drupal\entity_boilerplate\Entity\MyEntity\MyEntityUIController',
      'menu wildcard' => '%my_entity'
    ),
```

or we can get that info from

```
entity_info -> [admin ui][path]
```

Right now it leave it hardcoded, because I don't know the best solution
